### PR TITLE
Add maintainer (to receive ROS buildfarm error). Add Travis conf.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+# This config file for Travis CI utilizes https://github.com/ros-planning/moveit_ci/ package.
+sudo: required
+dist: trusty
+services:
+  - docker
+language: generic
+compiler:
+  - gcc
+notifications:
+  email:
+    recipients:
+      - dave@dav.ee
+      - 130s@2000.jukuin.keio.ac.jp
+env:
+  matrix:
+    - ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit_docs/kinetic-devel/moveit.rosinstall
+    - ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit_docs/kinetic-devel/moveit.rosinstall
+# matrix:
+#   allow_failures:
+#     - env: ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu         UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit_docs/kinetic-devel/moveit.rosinstall
+before_script:
+  - git clone -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
+script:
+  - source .moveit_ci/travis.sh

--- a/package.xml
+++ b/package.xml
@@ -4,8 +4,8 @@
   <version>0.2.0</version>
   <description>The manipulation_msgs package</description>
 
-  <maintainer email="jbinney@willowgarage.com">Jon Binney</maintainer>
-
+  <maintainer email="jon.binney@gmail.com">Jon Binney</maintainer>
+  <maintainer email="130s@2000.jukuin.keio.ac.jp">Isaac I. Y. Saito</maintainer>
 
   <license>BSD</license>
 


### PR DESCRIPTION
Last change made was 3 years ago so we can take a good advantage of adding CI.

Note:
- I'm only adding check for Kinetic (since I'm not sure how to add I-J support using moveit_ci.
- Travis needs enabled https://travis-ci.org/profile/ros-interactive-manipulation (I don't seem to have access rights).

@jonbinney 
I've updated your email, hoping you don't mind remaining as a maintainer
(I'm just working to make a release into Kinetic per request #7).
